### PR TITLE
Fix ZebraOSS crash triggered by enabling symbologies via barcode

### DIFF
--- a/enioka_scan/src/main/java/com/enioka/scanner/sdk/zebraoss/ZebraOssScanner.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/sdk/zebraoss/ZebraOssScanner.java
@@ -14,7 +14,6 @@ import com.enioka.scanner.api.proxies.ScannerStatusCallbackProxy;
 import com.enioka.scanner.bt.api.BluetoothScanner;
 import com.enioka.scanner.bt.api.DataSubscriptionCallback;
 import com.enioka.scanner.data.Barcode;
-import com.enioka.scanner.sdk.zebraoss.commands.ActivateAllSymbologies;
 import com.enioka.scanner.sdk.zebraoss.commands.Beep;
 import com.enioka.scanner.sdk.zebraoss.commands.InitCommand;
 import com.enioka.scanner.sdk.zebraoss.commands.LedOff;

--- a/enioka_scan/src/main/java/com/enioka/scanner/sdk/zebraoss/ZebraOssScanner.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/sdk/zebraoss/ZebraOssScanner.java
@@ -243,7 +243,6 @@ class ZebraOssScanner implements Scanner, Scanner.WithTriggerSupport, Scanner.Wi
 
         this.btScanner.runCommand(new InitCommand(), null);
         this.btScanner.runCommand(new SetPickListMode((byte) 2), null);
-        //this.btScanner.runCommand(new ActivateAllSymbologies(), null); // It's there if needed but not enabled by default
         this.btScanner.runCommand(new ScanEnable(), null);
 
         // We are already connected if the scanner could be created...

--- a/enioka_scan/src/main/java/com/enioka/scanner/sdk/zebraoss/ZebraOssScanner.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/sdk/zebraoss/ZebraOssScanner.java
@@ -243,7 +243,7 @@ class ZebraOssScanner implements Scanner, Scanner.WithTriggerSupport, Scanner.Wi
 
         this.btScanner.runCommand(new InitCommand(), null);
         this.btScanner.runCommand(new SetPickListMode((byte) 2), null);
-        this.btScanner.runCommand(new ActivateAllSymbologies(), null);
+        //this.btScanner.runCommand(new ActivateAllSymbologies(), null); // It's there if needed but not enabled by default
         this.btScanner.runCommand(new ScanEnable(), null);
 
         // We are already connected if the scanner could be created...

--- a/enioka_scan/src/main/java/com/enioka/scanner/sdk/zebraoss/ZebraOssScanner.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/sdk/zebraoss/ZebraOssScanner.java
@@ -14,6 +14,7 @@ import com.enioka.scanner.api.proxies.ScannerStatusCallbackProxy;
 import com.enioka.scanner.bt.api.BluetoothScanner;
 import com.enioka.scanner.bt.api.DataSubscriptionCallback;
 import com.enioka.scanner.data.Barcode;
+import com.enioka.scanner.sdk.zebraoss.commands.ActivateAllSymbologies;
 import com.enioka.scanner.sdk.zebraoss.commands.Beep;
 import com.enioka.scanner.sdk.zebraoss.commands.InitCommand;
 import com.enioka.scanner.sdk.zebraoss.commands.LedOff;
@@ -242,6 +243,7 @@ class ZebraOssScanner implements Scanner, Scanner.WithTriggerSupport, Scanner.Wi
 
         this.btScanner.runCommand(new InitCommand(), null);
         this.btScanner.runCommand(new SetPickListMode((byte) 2), null);
+        this.btScanner.runCommand(new ActivateAllSymbologies(), null);
         this.btScanner.runCommand(new ScanEnable(), null);
 
         // We are already connected if the scanner could be created...

--- a/enioka_scan/src/main/java/com/enioka/scanner/sdk/zebraoss/commands/ActivateAllSymbologies.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/sdk/zebraoss/commands/ActivateAllSymbologies.java
@@ -1,0 +1,9 @@
+package com.enioka.scanner.sdk.zebraoss.commands;
+
+import com.enioka.scanner.sdk.zebraoss.ssi.SsiCommand;
+
+public class ActivateAllSymbologies extends CommandExpectingNothing {
+    public ActivateAllSymbologies() {
+        super(SsiCommand.CHANGE_ALL_CODE_TYPES.getOpCode(), new byte[]{0x01});
+    }
+}

--- a/enioka_scan/src/main/java/com/enioka/scanner/sdk/zebraoss/ssi/SsiCommand.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/sdk/zebraoss/ssi/SsiCommand.java
@@ -25,7 +25,7 @@ public enum SsiCommand {
     SSI_MGMT_COMMAND(0x80, SsiSource.BOTH, true, new RsmResponseParser()),
     SCANNER_INIT_COMMAND(0x90, SsiSource.HOST),
     SCANNER_INIT(0x91, SsiSource.DECODER, new ScannerInitParser()),
-    TEMP_COMMAND(0x93, SsiSource.HOST),
+    TEMP_COMMAND(0x93, SsiSource.BOTH, true, new GenericParser()), // Not documented, source of problems
     REQUEST_REVISION(0xA3, SsiSource.HOST),
     REPLY_REVISION(0xA4, SsiSource.DECODER, false, new ReplyRevisionParser()),
     IMAGE_DATA(0xB1, SsiSource.DECODER, true, new GenericParser()),


### PR DESCRIPTION
When enabling symbologies via scanning a barcode, an unrecognized packet made the library crash. This fix stops the app from crashing and allows use of additional symbologies.