### PR TITLE
activate AZTEC Symbology on SPA43

### DIFF
--- a/enioka_scan/src/main/java/com/enioka/scanner/data/BarcodeType.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/data/BarcodeType.java
@@ -13,6 +13,7 @@ public enum BarcodeType {
     INT25("INT25"), // INTERLEAVED 2 OF 5
     EAN13("EAN13"), // EAN 13
     QRCODE("QRCODE"), // QR CODE (normal)
+    AZTEC("AZTEC"), // AZTEC 2D
     /**
      * On a result, means the scanner has not returned the information. On a scanner configuration, means the scanner should allow all codes.
      */

--- a/enioka_scan/src/main/java/com/enioka/scanner/sdk/athesi/SPA43LTE/AthesiHHTScanner.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/sdk/athesi/SPA43LTE/AthesiHHTScanner.java
@@ -45,6 +45,7 @@ public class AthesiHHTScanner extends IntentScanner<String> implements Scanner.W
         activeSymbologies.add(AthesiHHTSymbology.INT25);
         activeSymbologies.add(AthesiHHTSymbology.EAN13);
         activeSymbologies.add(AthesiHHTSymbology.QRCODE);
+        activeSymbologies.add(AthesiHHTSymbology.AZTEC);
     }
 
     private static final Uri scannerSettingsUri = Uri.parse("content://com.oem.startup.ScannerParaProvider/settings");

--- a/enioka_scan/src/main/java/com/enioka/scanner/sdk/athesi/SPA43LTE/AthesiHHTSymbology.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/sdk/athesi/SPA43LTE/AthesiHHTSymbology.java
@@ -67,7 +67,7 @@ enum AthesiHHTSymbology {
     MAXICODE(DataWedge.ENABLE_MAXICODE, DataWedge.DISABLE_MAXICODE, null, null),
     QRCODE(DataWedge.ENABLE_QRCODE, DataWedge.DISABLE_QRCODE, BarcodeType.QRCODE, 28),
     MICROQR(DataWedge.ENABLE_MICROQR, DataWedge.DISABLE_MICROQR, null, null),
-    AZTEC(DataWedge.ENABLE_AZTEC, DataWedge.DISABLE_AZTEC, null, null),
+    AZTEC(DataWedge.ENABLE_AZTEC, DataWedge.DISABLE_AZTEC, BarcodeType.AZTEC, 45),
     HAN_XIN(DataWedge.ENABLE_HAN_XIN, DataWedge.DISABLE_HAN_XIN, null, null),
 
     JAPAN(DataWedge.ENABLE_JAPAN, DataWedge.DISABLE_JAPAN, null, null),


### PR DESCRIPTION
Activate AZTEC as default symbology for SPA43