### PR TITLE
#81 - Upgrade github actions dependencies

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Get tag version
         id: get_version
-        run: echo ::set-output name=VERSION::$(echo $GITHUB_REF | cut -d / -f 3)
+        run: echo "VERSION=$(echo $GITHUB_REF | cut -d / -f 3)" >> $GITHUB_OUTPUT
       - name: Set up environment
         uses: actions/setup-java@v3
         with:
@@ -39,23 +39,11 @@ jobs:
           LIB_VERSION: ${{ steps.get_version.outputs.VERSION }}
           GH_DRIVER_REPOSITORY_USERNAME: ${{ secrets.GH_DRIVER_REPOSITORY_USERNAME }}
           GH_DRIVER_REPOSITORY_TOKEN: ${{ secrets.GH_DRIVER_REPOSITORY_TOKEN }}
-      - name: Create a GitHub release
-        id: create_release
-        uses: actions/create-release@v1 # No longer maintained
+      - name: Rename the AAR file for GitHub release upload
+        run: mv enioka_scan/build/outputs/aar/enioka_scan-release.aar enioka_scan/build/outputs/aar/enioka_scan-${{ steps.get_version.outputs.VERSION }}.aar
+      - name: Create a GitHub release with the AAR file as an asset
+        uses: softprops/action-gh-release@v1
         with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ steps.get_version.outputs.VERSION }}
-          draft: false
-          prerelease: false
-          files: enioka_scan/build/outputs/aar/enioka_scan-release.aar
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Upload AAR as GitHub release asset
-        uses: actions/upload-release-asset@v1 # No longer maintained
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: enioka_scan/build/outputs/aar/enioka_scan-release.aar
-          asset_name: enioka_scan-${{ steps.get_version.outputs.VERSION }}.aar
-          asset_content_type: application/android-archive
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          name: ${{ steps.get_version.outputs.VERSION }}
+          files: enioka_scan/build/outputs/aar/enioka_scan-${{ steps.get_version.outputs.VERSION }}.aar
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,12 +10,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Get tag version
         id: get_version
         run: echo ::set-output name=VERSION::$(echo $GITHUB_REF | cut -d / -f 3)
       - name: Set up environment
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: '17'
           distribution: 'zulu'
@@ -41,7 +41,7 @@ jobs:
           GH_DRIVER_REPOSITORY_TOKEN: ${{ secrets.GH_DRIVER_REPOSITORY_TOKEN }}
       - name: Create a GitHub release
         id: create_release
-        uses: actions/create-release@v1
+        uses: actions/create-release@v1 # No longer maintained
         with:
           tag_name: ${{ github.ref }}
           release_name: ${{ steps.get_version.outputs.VERSION }}
@@ -51,7 +51,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload AAR as GitHub release asset
-        uses: actions/upload-release-asset@v1
+        uses: actions/upload-release-asset@v1 # No longer maintained
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: enioka_scan/build/outputs/aar/enioka_scan-release.aar

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set up environment
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: '17'
           distribution: 'zulu'


### PR DESCRIPTION
Resolves #81 

- `gradle/gradle-build-action` already up-to-date 
- `actions/checkout` upgraded from v2 to v4
- `actions/setup-java` upgraded from v2 to v3
- `action/create-release` and `action/upload-release-asset` are archived as of 2021 and GH Actions warns of some of their commands getting disabled soon, so they were replaced with [softprops/action-gh-release](https://github.com/softprops/action-gh-release), suggested in both original actions' archival message.