### PR TITLE
#66 - Run integration tests in pipeline

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,17 +6,45 @@ on:
       - '*'
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
+  test:
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        api-level: [19, 28]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set up environment
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: '17'
           distribution: 'zulu'
-      - name: Build and test
+      - name: Gradle cache
         uses: gradle/gradle-build-action@v2
+      - name: AVD cache
+        uses: actions/cache@v3
+        id: avd-cache
         with:
-          arguments: build enioka_scan:test enioka_scan_mock:test
+          path: |
+            ~.android/avd/*
+            ~/.android/adb*
+          key: avd-${{ matrix.api-level }}
+      - name: Create AVD and generate snapshot for caching
+        if: steps.avd-cache.outputs.cache-hit != 'true'
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ matrix.api-level }}
+          force-avd-creation: false
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: false
+          script: echo "Generated AVD snapshot for caching"
+      - name: Run unit tests
+        run: ./gradlew check
+      - name: Run integration tests
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ matrix.api-level }}
+          force-avd-creation: false
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: true
+          script: ./gradlew connectedCheck


### PR DESCRIPTION
Resolves #66

Enable running android instrumented tests using [ReactiveCircus/android-emulator-runner](https://github.com/ReactiveCircus/android-emulator-runner).

Also add matrix checks to run tests on multiple API levels, right now 19 (enioka scan min version) and 28 (enioka scan target version).

Old workflow runtime: ~3min
New workflow runtime: ~9min