### PR TITLE
#91 - Change target color when camera is paused

### DIFF
--- a/enioka_scan/src/main/java/com/enioka/scanner/activities/ScannerCompatActivity.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/activities/ScannerCompatActivity.java
@@ -104,6 +104,8 @@ public class ScannerCompatActivity extends AppCompatActivity implements ScannerC
      */
     protected int scannerModeToggleViewId = R.id.scanner_switch_zxing;
 
+    protected int scannerModeTogglePauseId = R.id.scanner_switch_pause;
+
     protected int keyboardOpenViewId = R.id.scanner_bt_keyboard;
 
     /**
@@ -407,6 +409,7 @@ public class ScannerCompatActivity extends AppCompatActivity implements ScannerC
         displayTorch();
         displayManualInputButton();
         displayCameraReaderToggle();
+        displayCameraPauseToggle();
     }
 
 
@@ -634,6 +637,23 @@ public class ScannerCompatActivity extends AppCompatActivity implements ScannerC
             Log.i(LOG_TAG, "Changing reader mode");
             CameraBarcodeScanView cameraView = findViewById(cameraViewId);
             cameraView.setReaderMode(isChecked ? CameraReader.ZXING : CameraReader.ZBAR);
+        });
+    }
+
+    protected void displayCameraPauseToggle() {
+        final Switch toggle = findViewById(scannerModeTogglePauseId);
+        if (toggle == null) {
+            return;
+        }
+
+        toggle.setOnCheckedChangeListener((buttonView, isChecked) -> {
+            Log.i(LOG_TAG, "Toggling camera pause");
+            CameraBarcodeScanView cameraView = findViewById(cameraViewId);
+            if (isChecked) {
+                cameraView.pauseCamera();
+            } else {
+                cameraView.resumeCamera();
+            }
         });
     }
 

--- a/enioka_scan/src/main/java/com/enioka/scanner/camera/CameraBarcodeScanViewBase.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/camera/CameraBarcodeScanViewBase.java
@@ -64,7 +64,7 @@ abstract class CameraBarcodeScanViewBase<T> extends FrameLayout implements Scann
 
 
     protected SurfaceView camPreviewSurfaceView;
-    protected View targetView;
+    protected TargetView targetView;
     protected final TypedArray styledAttributes;
 
 
@@ -308,7 +308,7 @@ abstract class CameraBarcodeScanViewBase<T> extends FrameLayout implements Scann
     protected void addTargetView() {
         float rectHeightPixelsViewCoordinates = (float) RECT_HEIGHT / MM_INSIDE_INCH * ydpi;
 
-        final View targetView = new TargetView(this.getContext(), this.styledAttributes);
+        final TargetView targetView = new TargetView(this.getContext(), this.styledAttributes);
         targetView.setId(R.id.barcode_scanner_camera_view);
         final FrameLayout.LayoutParams prms = new FrameLayout.LayoutParams(LayoutParams.MATCH_PARENT, (int) rectHeightPixelsViewCoordinates);
         prms.setMargins(0, cropRect.top, 0, 0);

--- a/enioka_scan/src/main/java/com/enioka/scanner/camera/CameraBarcodeScanViewV1.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/camera/CameraBarcodeScanViewV1.java
@@ -479,6 +479,9 @@ class CameraBarcodeScanViewV1 extends CameraBarcodeScanViewBase<byte[]> implemen
             this.cam.setPreviewCallbackWithBuffer(null);
             this.cam.stopPreview();
         }
+        if (this.targetView != null) {
+            this.targetView.pauseTarget();
+        }
     }
 
     public void resumeCamera() {
@@ -487,6 +490,9 @@ class CameraBarcodeScanViewV1 extends CameraBarcodeScanViewBase<byte[]> implemen
             if (scanningStarted) {
                 this.cam.setPreviewCallback(this);
             }
+        }
+        if (this.targetView != null) {
+            this.targetView.resumeTarget();
         }
     }
 

--- a/enioka_scan/src/main/java/com/enioka/scanner/camera/CameraBarcodeScanViewV2.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/camera/CameraBarcodeScanViewV2.java
@@ -345,11 +345,17 @@ class CameraBarcodeScanViewV2 extends CameraBarcodeScanViewBase<Image> {
             this.captureSession.close();
             this.captureSession = null;
         }
+        if (this.targetView != null) {
+            this.targetView.pauseTarget();
+        }
     }
 
     @Override
     public void resumeCamera() {
         startPreview();
+        if (this.targetView != null) {
+            this.targetView.resumeTarget();
+        }
     }
 
     @Override

--- a/enioka_scan/src/main/java/com/enioka/scanner/camera/TargetView.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/camera/TargetView.java
@@ -26,17 +26,21 @@ class TargetView extends View {
     protected Rect targetRect = new Rect();
 
     @ColorInt
-    protected final int rectColor;
+    protected final int rectColorActive;
+    @ColorInt
+    protected final int rectColorPaused;
     protected final int rectStrokeWidth;
 
     public TargetView(Context context, @Nullable TypedArray styledAttributes) {
         super(context);
 
         if (styledAttributes != null) {
-            rectColor = styledAttributes.getColor(R.styleable.CameraBarcodeScanView_targetColor, Color.RED);
+            rectColorActive = styledAttributes.getColor(R.styleable.CameraBarcodeScanView_targetColorActive, Color.RED);
+            rectColorPaused = styledAttributes.getColor(R.styleable.CameraBarcodeScanView_targetColorPaused, Color.GRAY);
             rectStrokeWidth = styledAttributes.getInteger(R.styleable.CameraBarcodeScanView_targetStrokeWidth, 5);
         } else {
-            rectColor = Color.RED;
+            rectColorActive = Color.RED;
+            rectColorPaused = Color.GRAY;
             rectStrokeWidth = 5;
         }
 
@@ -45,7 +49,7 @@ class TargetView extends View {
 
     protected void init() {
         targetRectPaint = new Paint();
-        targetRectPaint.setColor(rectColor);
+        targetRectPaint.setColor(rectColorActive);
         targetRectPaint.setStrokeWidth(rectStrokeWidth);
         targetRectPaint.setStyle(Paint.Style.STROKE);
 
@@ -53,6 +57,18 @@ class TargetView extends View {
         guideLinePaint.setColor(Color.RED);
         guideLinePaint.setStyle(Paint.Style.STROKE);
         guideLinePaint.setPathEffect(new DashPathEffect(new float[]{5, 10, 15, 20}, 0));
+    }
+
+    public void pauseTarget() {
+        targetRectPaint.setColor(rectColorPaused);
+        guideLinePaint.setColor(rectColorPaused);
+        invalidate(); // Force redraw
+    }
+
+    public void resumeTarget() {
+        targetRectPaint.setColor(rectColorActive);
+        guideLinePaint.setColor(Color.RED);
+        invalidate(); // Force redraw
     }
 
     @Override
@@ -82,7 +98,6 @@ class TargetView extends View {
     @Override
     protected void onDraw(Canvas canvas) {
         super.onDraw(canvas);
-
         canvas.drawRect(targetRect, targetRectPaint);
         canvas.drawLine(0, (wholeView.bottom - wholeView.top) / 2, wholeView.right, (wholeView.bottom - wholeView.top) / 2, guideLinePaint);
     }

--- a/enioka_scan/src/main/res/layout/activity_main_alt.xml
+++ b/enioka_scan/src/main/res/layout/activity_main_alt.xml
@@ -20,7 +20,8 @@
         app:previewRatioMode="fillAvailableSpace"
         app:readerMode="Auto"
         app:storePreferredResolution="false"
-        app:targetColor="@color/colorRed"
+        app:targetColorActive="@color/colorRed"
+        app:targetColorPaused="@color/defaultItemColor"
         app:targetIsFixed="false"
         app:targetStrokeWidth="5"
         app:useAdaptiveResolution="true" />
@@ -81,4 +82,12 @@
         android:text="@string/activity_scan_use_zxing"
         app:layout_constraintRight_toRightOf="parent"
         app:layout_constraintTop_toBottomOf="@id/scanner_bt_keyboard" />
+
+    <Switch
+        android:id="@+id/scanner_switch_pause"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/activity_scan_pause_camera"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/scanner_switch_zxing" />
 </android.support.constraint.ConstraintLayout>

--- a/enioka_scan/src/main/res/values-fr/strings.xml
+++ b/enioka_scan/src/main/res/values-fr/strings.xml
@@ -34,4 +34,5 @@
     <string name="activity_scan_no_compatible_sdk">Aucun scanner compatible n\'est disponible sur cet appareil</string>
     <string name="service_description">Service d\'assistance à la gestion des scanners</string>
     <string name="activity_scan_use_zxing">ZXing</string>
+    <string name="activity_scan_pause_camera">Pause</string>
 </resources>

--- a/enioka_scan/src/main/res/values/attrs.xml
+++ b/enioka_scan/src/main/res/values/attrs.xml
@@ -11,7 +11,8 @@
             <enum name="ZXing" value="1" />
             <enum name="Auto" value="0" />
         </attr>
-        <attr name="targetColor" format="color" />
+        <attr name="targetColorActive" format="color" />
+        <attr name="targetColorPaused" format="color" />
         <attr name="targetStrokeWidth" format="integer" />
         <attr name="targetIsFixed" format="boolean" />
         <attr name="previewRatioMode" format="enum">

--- a/enioka_scan/src/main/res/values/strings.xml
+++ b/enioka_scan/src/main/res/values/strings.xml
@@ -35,6 +35,7 @@
     <string name="scanner_using_bt_keyboard">Using Bluetooth scanner or keyboard</string>
     <string name="activity_scan_no_compatible_sdk">There are no compatible scanners on this device</string>
     <string name="activity_scan_use_zxing">ZXing</string>
+    <string name="activity_scan_pause_camera">Pause</string>
 
     <!-- Helper manual scan fragment -->
     <string name="fragment_scan_manual_title">Manual input</string>


### PR DESCRIPTION
Resolves #91 

- Add pause toggle to camera view in default activity, hooked to camera's `pauseCamera()`/`resumeCamera()` methods.
- Differentiate target color in Active / Paused variants, defaults to RED for active and GRAY for paused.
- Add pause/resume methods to `TargetView` to change the target color when called by the `CameraBarcodeScanView`

![image](https://github.com/enioka-Haute-Couture/enioka_scan/assets/25197460/9914e431-ab9c-4071-b4da-ac510395053c)

![image](https://github.com/enioka-Haute-Couture/enioka_scan/assets/25197460/67412909-d244-4970-854a-29ebc5bb20fe)
