### PR TITLE
#86, #87 - Improve autofocus on target

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,8 @@ When there is no laser scanner available, or when a button is clicked, the `Scan
 
 The camera scanner can actually be used easily inside your own activities without any links with the rest of the library (no need to use the scanner service, etc) by just adding the `CameraBarcodeScanView` to your layouts, and then registering a callback on this view using `CameraBarcodeScanView.setResultHandler`. Other APIs are available to enable the torch or pause scanning.
 
+The provided Camera activity will display a target rectangle, which can be moved or tapped to change or refresh the autofocus area.
+
 # Developer quick start (modifying this library)
 
 ## Developing for Android

--- a/enioka_scan/src/main/java/com/enioka/scanner/camera/CameraBarcodeScanViewBase.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/camera/CameraBarcodeScanViewBase.java
@@ -343,6 +343,7 @@ abstract class CameraBarcodeScanViewBase<T> extends FrameLayout implements Scann
                     case MotionEvent.ACTION_UP:
                         dragStartY = 0;
                         v.performClick();
+                        this.refreshAutofocusZone();
                         ViewHelpersPreferences.storePreferences(getContext(), "y" + getDeviceOrientationRelativeToDeviceNaturalOrientation(), cropRect.top);
                         break;
                 }
@@ -351,6 +352,11 @@ abstract class CameraBarcodeScanViewBase<T> extends FrameLayout implements Scann
             });
         }
     }
+
+    /**
+     * Updates the camera's AF zone to the current position of the targetting rectangle.
+     */
+    abstract void refreshAutofocusZone();
 
     /**
      * Cropping method (according to the targeting rectangle)

--- a/enioka_scan/src/main/java/com/enioka/scanner/camera/CameraBarcodeScanViewV1.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/camera/CameraBarcodeScanViewV1.java
@@ -315,6 +315,10 @@ class CameraBarcodeScanViewV1 extends CameraBarcodeScanViewBase<byte[]> implemen
         }
     }
 
+    protected void refreshAutofocusZone() {
+        setAreas(this.cam.getParameters());
+    }
+
     public void setPreviewResolution(Point newResolution) {
         Camera.Parameters prms = this.cam.getParameters();
         pauseCamera();

--- a/enioka_scan/src/main/java/com/enioka/scanner/camera/CameraBarcodeScanViewV2.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/camera/CameraBarcodeScanViewV2.java
@@ -265,6 +265,23 @@ class CameraBarcodeScanViewV2 extends CameraBarcodeScanViewBase<Image> {
         return new MeteringRectangle(x0, y0, x1 - x0, y1 - y0, 1000);
     }
 
+    protected void refreshAutofocusZone() {
+        if (afZones > 0) {
+            captureRequestBuilder.set(CaptureRequest.CONTROL_AF_REGIONS, new MeteringRectangle[]{getMeteringZone()});
+            captureRequest = captureRequestBuilder.build();
+
+            try {
+                captureSession.stopRepeating();
+                captureSession.setRepeatingRequest(CameraBarcodeScanViewV2.this.captureRequest, null, backgroundHandler);
+            } catch (CameraAccessException | IllegalStateException e) {
+                Log.w(TAG, "Camera loop update has failed, this is usually due to changing resolution too fast. Error was: " + e.getMessage(), e);
+                CameraBarcodeScanViewV2.this.closeCamera();
+            }
+
+            Log.i(TAG, "Camera repeating capture request was updated " + CameraBarcodeScanViewV2.this.hashCode());
+        }
+    }
+
     private void openCamera() {
         Log.d(TAG, "Trying to open camera from CameraManager " + this.hashCode());
         if (ContextCompat.checkSelfPermission(getContext(), Manifest.permission.CAMERA) != PackageManager.PERMISSION_GRANTED) {

--- a/enioka_scan/src/main/java/com/enioka/scanner/camera/CameraBarcodeScanViewV2.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/camera/CameraBarcodeScanViewV2.java
@@ -256,12 +256,11 @@ class CameraBarcodeScanViewV2 extends CameraBarcodeScanViewBase<Image> {
     }
 
     private MeteringRectangle getMeteringZone() {
-        // TODO: use cropRect
-        // Coordinate system is 0 topleft/bottomright
-        int x0 = this.resolution.currentPreviewResolution.x / 2 - 50;
-        int y0 = this.resolution.currentPreviewResolution.y / 2 - 50;
-        int x1 = this.resolution.currentPreviewResolution.x / 2 + 50;
-        int y1 = this.resolution.currentPreviewResolution.y / 2 + 50;
+        // Coordinate system is 0 topleft / 1 bottomright
+        int x0 = this.cropRect.left;
+        int y0 = this.cropRect.top;
+        int x1 = this.cropRect.right;
+        int y1 = this.cropRect.bottom;
         Log.d(TAG, "Using metering zone (" + x0 + "," + y0 + ") (" + x1 + "," + y1 + ")");
         return new MeteringRectangle(x0, y0, x1 - x0, y1 - y0, 1000);
     }


### PR DESCRIPTION
Resolves #86 
Resolves #87 

- Make Camera2 autofocus zone match the target rectangle (was previously a square at the center of the screen)
- Make Camera1 & 2 autofocus zone "follow" the target whenever moved or tapped (it will trigger a re-focus on the target rectangle)