### PR TITLE
#84 - Remove device-specific camera hacks

### DIFF
--- a/enioka_scan/src/main/java/com/enioka/scanner/camera/CameraBarcodeScanViewBase.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/camera/CameraBarcodeScanViewBase.java
@@ -94,6 +94,7 @@ abstract class CameraBarcodeScanViewBase<T> extends FrameLayout implements Scann
         this.allowTargetDrag = !styledAttributes.getBoolean(R.styleable.CameraBarcodeScanView_targetIsFixed, false);
         this.resolution.useAdaptiveResolution = styledAttributes.getBoolean(R.styleable.CameraBarcodeScanView_useAdaptiveResolution, true);
         this.resolution.storePreferredResolution = styledAttributes.getBoolean(R.styleable.CameraBarcodeScanView_storePreferredResolution, true);
+        this.resolution.minResolutionY = styledAttributes.getInteger(R.styleable.CameraBarcodeScanView_minResolutionY, 720);
         this.resolution.maxResolutionY = styledAttributes.getInteger(R.styleable.CameraBarcodeScanView_maxResolutionY, 1080);
         this.resolution.maxDistortionRatio = styledAttributes.getFloat(R.styleable.CameraBarcodeScanView_maxDistortionRatio, 0.3f);
         initLayout();

--- a/enioka_scan/src/main/java/com/enioka/scanner/camera/CameraBarcodeScanViewV1.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/camera/CameraBarcodeScanViewV1.java
@@ -253,29 +253,8 @@ class CameraBarcodeScanViewV1 extends CameraBarcodeScanViewBase<byte[]> implemen
 
         // We now have a preview resolution for sure. (exception otherwise)
 
-        // COMPAT HACKS
-        switch (android.os.Build.MODEL) {
-            case "LG-H340n":
-                resolution.currentPreviewResolution = new Point(1600, 1200);
-                resolution.useAdaptiveResolution = false;
-                Log.i(TAG, "LG-H340n specific - using hard-coded preview resolution" + prms.getPreviewSize().width + "*" + prms.getPreviewSize().height + ". Ratio is " + ((float) prms.getPreviewSize().width / prms.getPreviewSize().height));
-                break;
-            case "SPA43LTE":
-                resolution.currentPreviewResolution = new Point(1280, 720);
-                resolution.useAdaptiveResolution = false;
-                Log.i(TAG, "SPA43LTE specific - using hard-coded preview resolution " + prms.getPreviewSize().width + "*" + prms.getPreviewSize().height + ". Ratio is " + ((float) prms.getPreviewSize().width / prms.getPreviewSize().height));
-                break;
-            case "Archos Sense 50X":
-                resolution.currentPreviewResolution = new Point(1280, 720);
-                resolution.useAdaptiveResolution = false;
-                Log.i(TAG, "Archos Sense 50X specific - using hard-coded preview resolution " + prms.getPreviewSize().width + "*" + prms.getPreviewSize().height + ". Ratio is " + ((float) prms.getPreviewSize().width / prms.getPreviewSize().height));
-                break;
-            default:
-                Log.i(TAG, "Using preview resolution " + resolution.currentPreviewResolution.x + "*" +
-                        resolution.currentPreviewResolution.y + ". Ratio is " +
-                        ((float) resolution.currentPreviewResolution.x / ((float) resolution.currentPreviewResolution.y)));
-        }
-
+        Log.i(TAG, "Using preview resolution " + resolution.currentPreviewResolution.x + "*" + resolution.currentPreviewResolution.y + "."
+                + " Ratio is " + ((float) resolution.currentPreviewResolution.x / ((float) resolution.currentPreviewResolution.y)));
         // Set a denormalized field - this is used widely in the class.
         prms.setPreviewSize(resolution.currentPreviewResolution.x, resolution.currentPreviewResolution.y);
     }

--- a/enioka_scan/src/main/java/com/enioka/scanner/camera/Resolution.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/camera/Resolution.java
@@ -37,6 +37,7 @@ class Resolution {
     // Adaptive resolution parameters
     boolean useAdaptiveResolution = true;
     boolean storePreferredResolution = true;
+    int minResolutionY;
     int maxResolutionY;
     float maxDistortionRatio;
 

--- a/enioka_scan/src/main/java/com/enioka/scanner/camera/ViewHelpersResolution.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/camera/ViewHelpersResolution.java
@@ -58,6 +58,11 @@ class ViewHelpersResolution {
                 continue;
             }
 
+            if (resolution.y < bag.minResolutionY) {
+                Log.d(TAG, "\t\tResolution is removed - it is lower than the minimum resolution configured in the view (" + bag.minResolutionY + ")");
+                continue;
+            }
+
             if (resolution.y > bag.maxResolutionY) {
                 Log.d(TAG, "\t\tResolution is removed - it is higher than the maximum resolution configured in the view (" + bag.maxResolutionY + ")");
                 continue;

--- a/enioka_scan/src/main/res/layout/activity_main_alt.xml
+++ b/enioka_scan/src/main/res/layout/activity_main_alt.xml
@@ -16,6 +16,7 @@
         app:layout_constraintRight_toRightOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         app:maxDistortionRatio="0.3"
+        app:minResolutionY="720"
         app:maxResolutionY="1080"
         app:previewRatioMode="fillAvailableSpace"
         app:readerMode="Auto"

--- a/enioka_scan/src/main/res/values/attrs.xml
+++ b/enioka_scan/src/main/res/values/attrs.xml
@@ -21,6 +21,7 @@
         </attr>
         <attr name="useAdaptiveResolution" format="boolean" />
         <attr name="storePreferredResolution" format="boolean" />
+        <attr name="minResolutionY" format="integer" />
         <attr name="maxResolutionY" format="integer" />
         <attr name="maxDistortionRatio" format="float" />
     </declare-styleable>


### PR DESCRIPTION
Resolves #84 

- Remove device-specific hacks in CameraV1.

As no crash or performance reduction was observed when removing the hacks, I assume the original purpose was to stop the adaptive resolution from being called repeatedly until the minimum resolution was reached, as lower resolutions do not seem to improve performance on these devices. To solve this, a minimum resolution is now enforced (720px minimum on the Y axis) below which the preview is considered unusable anyway (though 480px would likely still be fine). This means even if the adaptive resolution is called over and over, it will stop at a much more reasonable point.

Tested with SPA43LTE, no access to LG-H340n or Archos Sense 50X currently.

- No device-specific hacks were found in CameraV2.