### PR TITLE
Fix target pausing call to UI thread

### DIFF
--- a/enioka_scan/src/main/java/com/enioka/scanner/camera/CameraBarcodeScanViewV1.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/camera/CameraBarcodeScanViewV1.java
@@ -504,9 +504,11 @@ class CameraBarcodeScanViewV1 extends CameraBarcodeScanViewBase<byte[]> implemen
             this.cam.setPreviewCallbackWithBuffer(null);
             this.cam.stopPreview();
         }
-        if (this.targetView != null) {
-            this.targetView.pauseTarget();
-        }
+        post(() -> {
+            if (this.targetView != null) {
+                this.targetView.pauseTarget();
+            }
+        });
     }
 
     public void resumeCamera() {
@@ -516,9 +518,11 @@ class CameraBarcodeScanViewV1 extends CameraBarcodeScanViewBase<byte[]> implemen
                 this.cam.setPreviewCallback(this);
             }
         }
-        if (this.targetView != null) {
-            this.targetView.resumeTarget();
-        }
+        post(() -> {
+            if (this.targetView != null) {
+                this.targetView.resumeTarget();
+            }
+        });
     }
 
     public void startScanner() {

--- a/enioka_scan/src/main/java/com/enioka/scanner/camera/CameraBarcodeScanViewV2.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/camera/CameraBarcodeScanViewV2.java
@@ -405,17 +405,21 @@ class CameraBarcodeScanViewV2 extends CameraBarcodeScanViewBase<Image> {
             this.captureSession.close();
             this.captureSession = null;
         }
-        if (this.targetView != null) {
-            this.targetView.pauseTarget();
-        }
+        post(() -> {
+            if (this.targetView != null) {
+                this.targetView.pauseTarget();
+            }
+        });
     }
 
     @Override
     public void resumeCamera() {
         startPreview();
-        if (this.targetView != null) {
-            this.targetView.resumeTarget();
-        }
+        post(() -> {
+            if (this.targetView != null) {
+                this.targetView.resumeTarget();
+            }
+        });
     }
 
     @Override


### PR DESCRIPTION
While the method would work when called from a button on the activity, it would cause a crash if called from the code. The calls to targetView are now done on the UI thread.