### PR TITLE
Update gradle to 8.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.0.2'
+        classpath 'com.android.tools.build:gradle:8.1.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/demoscannerapp/build.gradle
+++ b/demoscannerapp/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 33
+    compileSdk 33
     defaultConfig {
         applicationId "com.enioka.scanner.demoscannerapp"
         minSdkVersion 19

--- a/enioka_scan/build.gradle
+++ b/enioka_scan/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'scanner.published-library'
 description('A library that makes the integration of all barcode scanners easy in any Android application, avoiding vendor lock-in and lowering the cost of advanced scanner integration.')
 
 android {
-    compileSdkVersion 33
+    compileSdk 33
     defaultConfig {
         minSdkVersion 19
         targetSdkVersion 28

--- a/enioka_scan_honeywell/build.gradle
+++ b/enioka_scan_honeywell/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'scanner.published-library'
 description 'Scanner provider for Honeywell devices using the official AIDC driver (not provided)'
 
 android {
-    compileSdkVersion 33
+    compileSdk 33
     defaultConfig {
         minSdkVersion 19
         targetSdkVersion 28

--- a/enioka_scan_koamtac/build.gradle
+++ b/enioka_scan_koamtac/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'scanner.published-library'
 description 'Scanner provider for Koamtac devices using the official KDC driver (not provided)'
 
 android {
-    compileSdkVersion 33
+    compileSdk 33
     defaultConfig {
         minSdkVersion 19
         targetSdkVersion 28

--- a/enioka_scan_m3/build.gradle
+++ b/enioka_scan_m3/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'scanner.published-library'
 description 'Scanner provider for M3 bluetooth ring devices using the official drivers (not provided)'
 
 android {
-    compileSdkVersion 33
+    compileSdk 33
     defaultConfig {
         minSdkVersion 19
         targetSdkVersion 28

--- a/enioka_scan_mock/build.gradle
+++ b/enioka_scan_mock/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 33
+    compileSdk 33
     defaultConfig {
         minSdkVersion 19
         targetSdkVersion 28

--- a/enioka_scan_zebra/build.gradle
+++ b/enioka_scan_zebra/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'scanner.published-library'
 description 'Scanner provider for Zebra devices using the official Zebra/Symbol drivers (not provided)'
 
 android {
-    compileSdkVersion 33
+    compileSdk 33
     defaultConfig {
         minSdkVersion 19
         targetSdkVersion 28

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,17 +1,14 @@
-# Project-wide Gradle settings.
-
-# IDE (e.g. Android Studio) users:
-# Gradle settings configured through the IDE *will override*
-# any settings specified in this file.
-
-# For more details on how to configure your build environment visit
+## For more details on how to configure your build environment visit
 # http://www.gradle.org/docs/current/userguide/build_environment.html
-
+#
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx1536m
-
+# Default value: -Xmx1024m -XX:MaxPermSize=256m
+# org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+#
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
+#Wed Sep 13 11:22:30 CEST 2023
+org.gradle.jvmargs=-Xmx2048M -Dkotlin.daemon.jvm.options\="-Xmx2048M"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Nov 11 15:49:33 CET 2020
+#Tue Sep 26 09:23:23 CEST 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip


### PR DESCRIPTION
Update Gradle dependencies to latest Android Studio stable release specs (Giraffe | 2022.3.1).

Also replace deprecated `compileSdkVersion` keyword with `compileSdk`.