### PR TITLE
#110 - Add support for HOST_ACK to SSI parser

### DIFF
--- a/enioka_scan/src/main/java/com/enioka/scanner/activities/ScannerCompatActivity.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/activities/ScannerCompatActivity.java
@@ -265,11 +265,11 @@ public class ScannerCompatActivity extends AppCompatActivity implements ScannerC
 
         // Bind to ScannerService service
         Intent intent = new Intent(this, ScannerService.class);
-        if (getIntent().getExtras() != null) {
-            intent.putExtras(getIntent().getExtras());
-        }
         if (getServiceInitExtras() != null) {
             intent.putExtras(getServiceInitExtras());
+        }
+        if (getIntent().getExtras() != null) {
+            intent.putExtras(getIntent().getExtras());
         }
         bindService(intent, connection, Context.BIND_AUTO_CREATE);
     }

--- a/enioka_scan/src/main/java/com/enioka/scanner/sdk/zebraoss/commands/Ack.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/sdk/zebraoss/commands/Ack.java
@@ -6,7 +6,7 @@ import com.enioka.scanner.sdk.zebraoss.ssi.SsiCommand;
  * A message or segment acknowledgment.
  */
 public class Ack extends CommandExpectingNothing {
-    public Ack() {
-        super(SsiCommand.CMD_ACK.getOpCode());
+    public Ack(boolean useHostAck) {
+        super(useHostAck ? SsiCommand.HOST_ACK.getOpCode() : SsiCommand.CMD_ACK.getOpCode());
     }
 }

--- a/enioka_scan/src/main/java/com/enioka/scanner/sdk/zebraoss/ssi/SsiCommand.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/sdk/zebraoss/ssi/SsiCommand.java
@@ -24,8 +24,9 @@ public enum SsiCommand {
     MULTIPACKET_ACK(0x74, SsiSource.HOST), // Triggered directly in the parser
     SSI_MGMT_COMMAND(0x80, SsiSource.BOTH, true, new RsmResponseParser()),
     SCANNER_INIT_COMMAND(0x90, SsiSource.HOST),
-    SCANNER_INIT(0x91, SsiSource.DECODER, new ScannerInitParser()),
+    SCANNER_INIT_RESPONSE(0x91, SsiSource.DECODER, new ScannerInitParser()), // If received after a SCANNER_INIT_COMMAND, use HOST_ACK instead of CMD_ACK
     TEMP_COMMAND(0x93, SsiSource.BOTH, true, new GenericParser()), // Not documented, source of problems
+    HOST_ACK(0x96, SsiSource.HOST),
     REQUEST_REVISION(0xA3, SsiSource.HOST),
     REPLY_REVISION(0xA4, SsiSource.DECODER, false, new ReplyRevisionParser()),
     IMAGE_DATA(0xB1, SsiSource.DECODER, true, new GenericParser()),


### PR DESCRIPTION
Resolves #110 

Use HOST_ACK (0x96) instead of CMD_ACK (0xD0) if the scanner replies to the INIT_COMMAND (0x90) with a 0x91 response.

If ignored and CMD_ACK is used, the device would lock itself for a few seconds after each action while awaiting for the HOST_ACK that never comes. This change fixes that problem and the scanner becomes available again immediately after a successful scan.

Also fix the handling of scanner search options handling in `ScannerCompatActivity` where settings from the intent that started the activity would be overridden by defaults, meaning Bluetooth would always be disabled during the search.