### PR TITLE
Add safeguards for null camera attributes

### DIFF
--- a/enioka_scan/src/main/java/com/enioka/scanner/camera/CameraBarcodeScanViewV1.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/camera/CameraBarcodeScanViewV1.java
@@ -301,6 +301,11 @@ class CameraBarcodeScanViewV1 extends CameraBarcodeScanViewBase<byte[]> implemen
     }
 
     protected void refreshAutofocusZone() {
+        if (this.cam == null) {
+            Log.w(VIEW_LOG_TAG, "refreshAutofocusZone: No camera instance, make sure camera was properly initialized and `cleanup()` or `closeCamera()` were not called previously");
+            return;
+        }
+
         if (autoFocusMode == null) {
             return;
         }
@@ -327,6 +332,11 @@ class CameraBarcodeScanViewV1 extends CameraBarcodeScanViewBase<byte[]> implemen
     }
 
     public void setPreviewResolution(Point newResolution) {
+        if (this.cam == null) {
+            Log.w(VIEW_LOG_TAG, "setPreviewResolution: No camera instance, make sure camera was properly initialized and `cleanup()` or `closeCamera()` were not called previously");
+            return;
+        }
+
         Camera.Parameters prms = this.cam.getParameters();
         pauseCamera();
         resolution.currentPreviewResolution = newResolution;
@@ -337,6 +347,11 @@ class CameraBarcodeScanViewV1 extends CameraBarcodeScanViewBase<byte[]> implemen
     }
 
     private void setInitialBuffers(Camera.Parameters prms) {
+        if (this.cam == null) {
+            Log.w(VIEW_LOG_TAG, "setInitialBuffers: No camera instance, make sure camera was properly initialized and `cleanup()` or `closeCamera()` were not called previously");
+            return;
+        }
+
         previewBufferSize = (int) (resolution.currentPreviewResolution.x * resolution.currentPreviewResolution.y * ImageFormat.getBitsPerPixel(prms.getPreviewFormat()) / 8f);
         for (int i = 0; i < Runtime.getRuntime().availableProcessors() * 2; i++) {
             this.cam.addCallbackBuffer(new byte[previewBufferSize]);
@@ -381,6 +396,11 @@ class CameraBarcodeScanViewV1 extends CameraBarcodeScanViewBase<byte[]> implemen
 
     @Override
     void setTorchInternal(boolean value) {
+        if (this.cam == null) {
+            Log.w(VIEW_LOG_TAG, "setTorchInternal: No camera instance, make sure camera was properly initialized and `cleanup()` or `closeCamera()` were not called previously");
+            return;
+        }
+
         Camera.Parameters prms = this.cam.getParameters();
         if (value) {
             prms.setFlashMode(Camera.Parameters.FLASH_MODE_TORCH);
@@ -403,6 +423,11 @@ class CameraBarcodeScanViewV1 extends CameraBarcodeScanViewBase<byte[]> implemen
      * @param prms Instance of camera configuration to apply
      */
     public void setCameraParameters(Camera.Parameters prms) {
+        if (this.cam == null) {
+            Log.w(VIEW_LOG_TAG, "setCameraParameters: No camera instance, make sure camera was properly initialized and `cleanup()` or `closeCamera()` were not called previously");
+            return;
+        }
+
         try {
             this.cam.setParameters(prms);
         } catch (Exception e) {
@@ -468,6 +493,11 @@ class CameraBarcodeScanViewV1 extends CameraBarcodeScanViewBase<byte[]> implemen
     }
 
     public void giveBufferBackInternal(FrameAnalysisContext<byte[]> ctx) {
+        if (this.cam == null) {
+            Log.w(VIEW_LOG_TAG, "giveBufferBackInternal: No camera instance, make sure camera was properly initialized and `cleanup()` or `closeCamera()` were not called previously");
+            return;
+        }
+
         if (ctx.originalImage.length == previewBufferSize) {
             this.cam.addCallbackBuffer(ctx.originalImage);
         }
@@ -482,6 +512,8 @@ class CameraBarcodeScanViewV1 extends CameraBarcodeScanViewBase<byte[]> implemen
         if (this.cam != null) {
             this.cam.setPreviewCallbackWithBuffer(null);
             this.cam.stopPreview();
+        } else {
+            Log.w(VIEW_LOG_TAG, "pauseCamera: No camera instance, make sure camera was properly initialized and `cleanup()` or `closeCamera()` were not called previously");
         }
         post(() -> {
             if (this.targetView != null) {
@@ -496,6 +528,8 @@ class CameraBarcodeScanViewV1 extends CameraBarcodeScanViewBase<byte[]> implemen
             if (scanningStarted) {
                 this.cam.setPreviewCallback(this);
             }
+        } else {
+            Log.w(VIEW_LOG_TAG, "resumeCamera: No camera instance, make sure camera was properly initialized and `cleanup()` or `closeCamera()` were not called previously");
         }
         post(() -> {
             if (this.targetView != null) {
@@ -505,6 +539,10 @@ class CameraBarcodeScanViewV1 extends CameraBarcodeScanViewBase<byte[]> implemen
     }
 
     public void startScanner() {
+        if (this.cam == null) {
+            Log.w(VIEW_LOG_TAG, "startScanner: No camera instance, make sure camera was properly initialized and `cleanup()` or `closeCamera()` were not called previously");
+            return;
+        }
         Log.d(VIEW_LOG_TAG, "Scanning started");
         this.scanningStarted = true;
         this.cam.setPreviewCallback(this);
@@ -520,20 +558,24 @@ class CameraBarcodeScanViewV1 extends CameraBarcodeScanViewBase<byte[]> implemen
     ////////////////////////////////////////////////////////////////////////////////////////////////
     // Clean up methods
     public void cleanUp() {
-        if (this.cam != null) {
-            Log.i(TAG, "Removing all camera callbacks and stopping it");
-            this.cam.setPreviewCallback(null);
-            this.cam.stopPreview();
-            this.setOnClickListener(null);
-            this.lastSuccessfulScanData = null;
-            this.frameAnalyser.close();
-            this.frameAnalyser = null;
+        if (this.cam == null) {
+            Log.w(VIEW_LOG_TAG, "cleanup: No camera instance, make sure camera was properly initialized and `cleanup()` or `closeCamera()` were not called previously");
+            return;
         }
+
+        Log.i(TAG, "Removing all camera callbacks and stopping it");
+        this.cam.setPreviewCallback(null);
+        this.cam.stopPreview();
+        this.setOnClickListener(null);
+        this.lastSuccessfulScanData = null;
+        this.frameAnalyser.close();
+        this.frameAnalyser = null;
         closeCamera();
     }
 
     void closeCamera() {
         if (this.cam == null) {
+            Log.w(VIEW_LOG_TAG, "closeCamera: No camera instance, make sure camera was properly initialized and `cleanup()` or `closeCamera()` were not called previously");
             return;
         }
         Log.i(TAG, "Camera is being released");

--- a/enioka_scan/src/main/java/com/enioka/scanner/camera/CameraBarcodeScanViewV2.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/camera/CameraBarcodeScanViewV2.java
@@ -499,7 +499,7 @@ class CameraBarcodeScanViewV2 extends CameraBarcodeScanViewBase<Image> {
             if (value) {
                 captureRequestBuilder.set(CaptureRequest.FLASH_MODE, CaptureRequest.FLASH_MODE_TORCH);
             } else {
-                captureRequestBuilder.set(CaptureRequest.FLASH_MODE, null);
+                captureRequestBuilder.set(CaptureRequest.FLASH_MODE, CaptureRequest.FLASH_MODE_OFF);
             }
             if (captureSession != null) {
                 captureSession.stopRepeating();

--- a/enioka_scan/src/main/java/com/enioka/scanner/camera/CameraBarcodeScanViewV2.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/camera/CameraBarcodeScanViewV2.java
@@ -86,6 +86,37 @@ class CameraBarcodeScanViewV2 extends CameraBarcodeScanViewBase<Image> {
         init();
     }
 
+    /**
+     * Checks all attributes necessary for camera operations and returns true if any is null.
+     * None of these attributes are expected to be null unless the camera is either uninitialized, paused or closed.
+     *
+     * @param caller The name of the caller function, for logging
+     * @return true if any camera-related attribute is null.
+     */
+    private boolean anyAttributeMissing(String caller) {
+        if (cameraManager == null) {
+            Log.w(TAG, caller + ": No cameraManager instance, make sure camera was properly initialized");
+            return true;
+        }
+        if (captureSession == null) {
+            Log.w(TAG, caller + ": No captureSession instance, make sure camera was properly initialized and `pauseCamera()` or `closeCamera()` were not called previously");
+            return true;
+        }
+        if (captureRequestBuilder == null) {
+            Log.w(TAG, caller + ": No captureRequestBuilder instance, make sure camera was properly initialized and `closeCamera()` was not called previously");
+            return true;
+        }
+        if (cameraDevice == null) {
+            Log.w(TAG, caller + ": No cameraDevice instance, make sure camera was properly initialized and not used by another application or view, and `closeCamera()` was not called previously");
+            return true;
+        }
+        if (imageReader == null) {
+            Log.w(TAG, caller + ": No imageReader instance, make sure camera was properly initialized and `pauseCamera()` or `closeCamera()` were not called previously");
+            return true;
+        }
+        return false;
+    }
+
     private void init() {
         Log.d(TAG, "Camera2 specific initialization start");
 
@@ -287,6 +318,10 @@ class CameraBarcodeScanViewV2 extends CameraBarcodeScanViewBase<Image> {
     }
 
     protected void refreshAutofocusZone() {
+        if (anyAttributeMissing("refreshAutofocusZone")) {
+            return;
+        }
+
         if (afZones > 0) {
             CameraCaptureSession.CaptureCallback captureHandler = new CameraCaptureSession.CaptureCallback() {
                 @Override
@@ -380,11 +415,15 @@ class CameraBarcodeScanViewV2 extends CameraBarcodeScanViewBase<Image> {
         if (null != captureSession) {
             Log.d(TAG, " * Closing camera capture session");
 
-            captureRequestBuilder.removeTarget(this.camPreviewSurfaceView.getHolder().getSurface());
-            captureRequestBuilder = null;
-
             captureSession.close();
             captureSession = null;
+        }
+
+        if (null != captureRequestBuilder) {
+            Log.d(TAG, " * Clearing camera capture builder");
+
+            captureRequestBuilder.removeTarget(this.camPreviewSurfaceView.getHolder().getSurface());
+            captureRequestBuilder = null;
         }
 
         if (null != cameraDevice) {
@@ -452,9 +491,10 @@ class CameraBarcodeScanViewV2 extends CameraBarcodeScanViewBase<Image> {
 
     @Override
     void setTorchInternal(boolean value) {
-        if (captureSession == null) {
+        if (anyAttributeMissing("setTorchInternal")) {
             return;
         }
+
         try {
             if (value) {
                 captureRequestBuilder.set(CaptureRequest.FLASH_MODE, CaptureRequest.FLASH_MODE_TORCH);
@@ -768,7 +808,7 @@ class CameraBarcodeScanViewV2 extends CameraBarcodeScanViewBase<Image> {
             }
 
             // Sanity check
-            if (image.getPlanes()[0].getPixelStride() != 1) {
+            if (image.getPlanes()[0].getPixelStride() != 1 || image.getPlanes()[0].getBuffer() == null) {
                 throw new RuntimeException("not a luminance buffer");
             }
 
@@ -918,7 +958,7 @@ class CameraBarcodeScanViewV2 extends CameraBarcodeScanViewBase<Image> {
         // Copy Y channel.
         int yRowStride = yPlane.getRowStride();
         int yPixelStride = yPlane.getPixelStride();
-        for(int y = 0; y < height; ++y) {
+        for (int y = 0; y < height; ++y) {
             for (int x = 0; x < width; ++x) {
                 nv21[index++] = yBuffer.get(y * yRowStride + x * yPixelStride);
             }
@@ -931,7 +971,7 @@ class CameraBarcodeScanViewV2 extends CameraBarcodeScanViewBase<Image> {
         int uvWidth = width / 2;
         int uvHeight = height / 2;
 
-        for(int y = 0; y < uvHeight; ++y) {
+        for (int y = 0; y < uvHeight; ++y) {
             for (int x = 0; x < uvWidth; ++x) {
                 int bufferIndex = (y * uvRowStride) + (x * uvPixelStride);
                 // V channel.
@@ -949,7 +989,7 @@ class CameraBarcodeScanViewV2 extends CameraBarcodeScanViewBase<Image> {
         if (lastSuccessfulScanData != null) {
             Log.d(TAG, "Convert last saved image to JPEG");
             ByteArrayOutputStream buffer = new ByteArrayOutputStream();
-            YuvImage img = mediaImageToYuvImage((Image)lastSuccessfulScanData.originalImage);
+            YuvImage img = mediaImageToYuvImage((Image) lastSuccessfulScanData.originalImage);
             Rect imgRect = new Rect(0, 0, resolution.currentPreviewResolution.x, resolution.currentPreviewResolution.y);
             img.compressToJpeg(imgRect, 100, buffer);
 


### PR DESCRIPTION
Add checks for null attributes in Camera V1/V2 methods. Once reached, instead of crashing the method will simply do nothing.

Related to:
- #134 
- #135
- #136 (likely)
- #138 
- #139
- #140 
- #141

It is important to note that these attributes can only become null when manually set that way through closing methods, or when automatically cleaned during the normal Android lifecycle, so reaching these guards is equivalent to a "use after free".

Most of the crashes observed in the issues could not be replicated.