### PR TITLE
#148 - Add target reset function to camera view

### DIFF
--- a/enioka_scan/src/main/java/com/enioka/scanner/camera/CameraBarcodeScanView.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/camera/CameraBarcodeScanView.java
@@ -177,4 +177,11 @@ public class CameraBarcodeScanView extends FrameLayout {
     public void resumeCamera() {
         this.proxiedView.resumeCamera();
     }
+
+    /**
+     * Reset the vertical position of the target. Also resets the associated preferences.
+     */
+    public void resetTargetPosition() {
+        this.proxiedView.resetTargetPosition();
+    }
 }

--- a/enioka_scan/src/main/java/com/enioka/scanner/camera/CameraBarcodeScanViewBase.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/camera/CameraBarcodeScanViewBase.java
@@ -354,6 +354,17 @@ abstract class CameraBarcodeScanViewBase<T> extends FrameLayout implements Scann
         }
     }
 
+    public void resetTargetPosition() {
+        final boolean saveAllowTargetDrag = allowTargetDrag;
+        allowTargetDrag = false;
+        computeCropRectangle();
+        allowTargetDrag = saveAllowTargetDrag;
+
+        final FrameLayout.LayoutParams prms = (LayoutParams) targetView.getLayoutParams();
+        prms.topMargin = cropRect.top;
+        targetView.setLayoutParams(prms);
+    }
+
     /**
      * Updates the camera's AF zone to the current position of the targetting rectangle.
      */


### PR DESCRIPTION
#148

Camera View now has a public method (unused by default) to reset the position of the target.