### PR TITLE
#160 - Force-enable all symbologies for ZebraOSS

### DIFF
--- a/enioka_scan/src/main/java/com/enioka/scanner/sdk/zebraoss/ZebraOssScanner.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/sdk/zebraoss/ZebraOssScanner.java
@@ -15,6 +15,7 @@ import com.enioka.scanner.bt.api.BluetoothScanner;
 import com.enioka.scanner.bt.api.DataSubscriptionCallback;
 import com.enioka.scanner.data.Barcode;
 import com.enioka.scanner.data.BarcodeType;
+import com.enioka.scanner.sdk.zebraoss.commands.ActivateAllSymbologies;
 import com.enioka.scanner.sdk.zebraoss.commands.Beep;
 import com.enioka.scanner.sdk.zebraoss.commands.InitCommand;
 import com.enioka.scanner.sdk.zebraoss.commands.LedOff;
@@ -244,6 +245,7 @@ class ZebraOssScanner implements Scanner, Scanner.WithTriggerSupport, Scanner.Wi
 
         this.btScanner.runCommand(new InitCommand(), null);
         this.btScanner.runCommand(new SetPickListMode((byte) 2), null);
+        this.btScanner.runCommand(new ActivateAllSymbologies(), null);
         this.btScanner.runCommand(new ScanEnable(), null);
 
         // We are already connected if the scanner could be created...


### PR DESCRIPTION
#160 

Call command to enable all symbologies on ZebraOSS devices (no option to use a specific list, either all or nothing).

Warning: could not be tested on an actual device (dead battery).