### PR TITLE
Fix NPE for DW sdk during illumination config #162

### DIFF
--- a/enioka_scan_zebra_dw/src/main/java/com/enioka/scanner/sdk/zebra/dw/ZebraDwScanner.java
+++ b/enioka_scan_zebra_dw/src/main/java/com/enioka/scanner/sdk/zebra/dw/ZebraDwScanner.java
@@ -85,7 +85,8 @@ public class ZebraDwScanner extends IntentScanner<String> implements Scanner.Wit
                 if (this.currentlyActiveProfile != null && this.currentlyActiveProfile.equals(currentConfig.getProfileName())) {
                     configureSymbologies();
                 }
-                illuminationOn = !currentConfig.getParameter("BARCODE", "illumination_mode").equals("off");
+                final String illumination_mode = currentConfig.getParameter("BARCODE", "illumination_mode");
+                illuminationOn = illumination_mode != null && !illumination_mode.equals("off");
             }
         }
 


### PR DESCRIPTION
NPE could happen if no `illumination_mode` parameter was present in the config.