### PR TITLE
Fix/Optimize ZebraDwScanner lifecycle and intent handling

### DIFF
--- a/enioka_scan_zebra_dw/src/main/java/com/enioka/scanner/sdk/zebra/dw/ZebraDwSymbology.java
+++ b/enioka_scan_zebra_dw/src/main/java/com/enioka/scanner/sdk/zebra/dw/ZebraDwSymbology.java
@@ -7,11 +7,13 @@ import com.enioka.scanner.data.BarcodeType;
  */
 enum ZebraDwSymbology {
     // Items supported by the lib
-    CODE39("LABEL-TYPE-CODE39", "decoder_code39", BarcodeType.CODE39),
     CODE128("LABEL-TYPE-CODE128", "decoder_code128", BarcodeType.CODE128),
+    CODE39("LABEL-TYPE-CODE39", "decoder_code39", BarcodeType.CODE39),
     DIS25("LABEL-TYPE-D2OF5", "decoder_d2of5", BarcodeType.DIS25),
     INT25("LABEL-TYPE-I2OF5", "decoder_i2of5", BarcodeType.INT25),
     EAN13("LABEL-TYPE-EAN13", "decoder_ean13", BarcodeType.EAN13),
+    QRCODE("LABEL-TYPE-QRCODE", "decoder_qrcode", BarcodeType.QRCODE),
+    AZTEC("LABEL-TYPE-AZTEC", "decoder_aztec", BarcodeType.AZTEC),
     UNKNOWN("none", "none", BarcodeType.UNKNOWN);
 
     // Items not supported by the lib. Present because we need to be able to disable them.


### PR DESCRIPTION
#169 
#172 

Attempt to fix DW-related problems, most likely linked to profile handling.

- paused Scanner still received and handled intents, which could generate config loops and lower performances, now the receiver returns immediately if the scanner is paused
- wrong intent was called during pause/resume lifecycle steps, now disables the profile's scanning instead of datawedge as a whole
- add missing QRCODE and AZTEC symbologies to the DW symbology list