### PR TITLE
178 - CI: integration tests no longer work, adb cannot find the emulator

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   test:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         api-level: [19, 28]


### PR DESCRIPTION
- Switch GitHub action runner from MacOS to Ubuntu, in order to have an x86-64 architecture instead of ArmV8 (see https://github.com/AntennaPod/AntennaPod/pull/7140).