### PR TITLE
168 - Refactor code to better account for new ScannerSearchOptions

### DIFF
--- a/demoscannerapp/src/main/java/com/enioka/scanner/demo/WelcomeActivity.java
+++ b/demoscannerapp/src/main/java/com/enioka/scanner/demo/WelcomeActivity.java
@@ -85,14 +85,12 @@ public class WelcomeActivity extends AppCompatActivity {
         options.allowIntentDevices = preferences.getBoolean(ScannerServiceApi.EXTRA_SEARCH_ALLOW_INTENT_BOOLEAN, options.allowIntentDevices);
         options.allowedProviderKeys = preferences.getStringSet(ScannerServiceApi.EXTRA_SEARCH_ALLOWED_PROVIDERS_STRING_ARRAY, options.allowedProviderKeys);
         options.excludedProviderKeys = preferences.getStringSet(ScannerServiceApi.EXTRA_SEARCH_EXCLUDED_PROVIDERS_STRING_ARRAY, options.excludedProviderKeys);
+        options.symbologySelection = preferences.getStringSet(ScannerServiceApi.EXTRA_SYMBOLOGY_SELECTION, ScannerService.defaultSymbologyByName());
 
         options.toIntentExtras(intent);
-        // add symbology
-        final String[] symbologies = preferences.getStringSet(ScannerServiceApi.EXTRA_SYMBOLOGY_SELECTION, ScannerService.defaultSymbologyByName()).toArray(new String[0]);
-        intent.putExtra(ScannerServiceApi.EXTRA_SYMBOLOGY_SELECTION, symbologies);
-        // add logging intent extra
+
+        // Add extra settings for scanner activity (logging and camera fallback)
         intent.putExtra(SettingsActivity.ENABLE_LOGGING_KEY, preferences.getBoolean(SettingsActivity.ENABLE_LOGGING_KEY, false));
-        // add allow camera fallback intent extra
         intent.putExtra(SettingsActivity.ALLOW_CAMERA_FALLBACK_KEY, preferences.getBoolean(SettingsActivity.ALLOW_CAMERA_FALLBACK_KEY, false));
         // add enable keep aspect ratio intent extra
         intent.putExtra(SettingsActivity.ENABLE_KEEP_ASPECT_RATIO_KEY, preferences.getBoolean(SettingsActivity.ENABLE_KEEP_ASPECT_RATIO_KEY, false) ? 1 : 0);

--- a/enioka_scan/src/androidTest/java/com/enioka/scanner/service/ScannerServiceAndroidTest.java
+++ b/enioka_scan/src/androidTest/java/com/enioka/scanner/service/ScannerServiceAndroidTest.java
@@ -63,10 +63,10 @@ public class ScannerServiceAndroidTest {
         options.useBlueTooth = false;
         options.allowedProviderKeys = new HashSet<>();
         options.allowedProviderKeys.add(MockProvider.PROVIDER_KEY);
+        options.startSearchOnServiceBind = false;
 
         final Intent serviceIntent = new Intent(ctx, ScannerService.class);
         options.toIntentExtras(serviceIntent);
-        serviceIntent.putExtra(ScannerServiceApi.EXTRA_START_SEARCH_ON_SERVICE_BIND, false);
         ctx.bindService(serviceIntent, serviceConnection, Context.BIND_AUTO_CREATE);
 
         // Wait for binding with ScannerService


### PR DESCRIPTION
https://github.com/enioka-Haute-Couture/enioka_scan/issues/168

- Remove explicit intent when `ScannerSearchOptions` can be used.