### PR TITLE
fix: Check that Zxing scanner is init before setting hints

### DIFF
--- a/enioka_scan_camera/src/main/java/com/enioka/scanner/sdk/camera/ZXingFrameAnalyser.java
+++ b/enioka_scan_camera/src/main/java/com/enioka/scanner/sdk/camera/ZXingFrameAnalyser.java
@@ -73,6 +73,11 @@ class ZXingFrameAnalyser extends FrameAnalyser {
             return;
         }
         symbologies.add(zXingSymbology);
+
+        if (this.scanner == null) {
+            initScanner();
+        }
+
         this.scanner.setHints(hints);
     }
 


### PR DESCRIPTION
https://github.com/enioka-Haute-Couture/enioka_scan/issues/195

- On `Zxing` frame analyzer, check that `this.scanner` instance is correctly init (not `null`) before settings hints.