### PR TITLE
204 -  Camera preview freezes on the demo-app

### DIFF
--- a/enioka_scan_camera/src/main/java/com/enioka/scanner/sdk/camera/CameraBarcodeScanView.java
+++ b/enioka_scan_camera/src/main/java/com/enioka/scanner/sdk/camera/CameraBarcodeScanView.java
@@ -185,6 +185,10 @@ public class CameraBarcodeScanView extends FrameLayout {
         this.proxiedView.resumeCamera();
     }
 
+    public void resetSurface() {
+        this.proxiedView.resetSurface();
+    }
+
     /**
      * Reset the vertical position of the target. Also resets the associated preferences.
      */

--- a/enioka_scan_camera/src/main/java/com/enioka/scanner/sdk/camera/CameraBarcodeScanViewBase.java
+++ b/enioka_scan_camera/src/main/java/com/enioka/scanner/sdk/camera/CameraBarcodeScanViewBase.java
@@ -189,6 +189,8 @@ abstract class CameraBarcodeScanViewBase<T> extends FrameLayout implements Scann
 
     public abstract void orientationChanged();
 
+    public abstract void resetSurface();
+
     /**
      * Indicate if the torch mode is handled or not
      *

--- a/enioka_scan_camera/src/main/java/com/enioka/scanner/sdk/camera/CameraBarcodeScanViewScanner.java
+++ b/enioka_scan_camera/src/main/java/com/enioka/scanner/sdk/camera/CameraBarcodeScanViewScanner.java
@@ -33,6 +33,9 @@ public class CameraBarcodeScanViewScanner implements Scanner, Scanner.WithBeepSu
         this.dataDb = mHandler;
         this.scanner = cameraBarcodeScanView;
 
+        // Reset camera in case the surface was not destroyed by Android lifecycle
+        scanner.resetSurface();
+
         scanner.setResultHandler(this);
         scanner.setTorch(false);
         for(BarcodeType symbology: symbologySelection) {

--- a/enioka_scan_camera/src/main/java/com/enioka/scanner/sdk/camera/CameraBarcodeScanViewV1.java
+++ b/enioka_scan_camera/src/main/java/com/enioka/scanner/sdk/camera/CameraBarcodeScanViewV1.java
@@ -37,6 +37,8 @@ class CameraBarcodeScanViewV1 extends CameraBarcodeScanViewBase<byte[]> implemen
     protected boolean scanningStarted = true;
 
     private int previewBufferSize;
+    private boolean isSurfaceCreated = false;
+    private SurfaceHolder cameraSurfaceHolder;
 
 
     ////////////////////////////////////////////////////////////////////////////////////////////////
@@ -469,6 +471,8 @@ class CameraBarcodeScanViewV1 extends CameraBarcodeScanViewBase<byte[]> implemen
     @Override
     public void surfaceCreated(@NonNull SurfaceHolder surfaceHolder) {
         super.surfaceCreated(surfaceHolder);
+        cameraSurfaceHolder = surfaceHolder;
+        isSurfaceCreated = true;
 
         Log.d(TAG, "Preview surface created, camera will be initialized soon");
 
@@ -497,8 +501,20 @@ class CameraBarcodeScanViewV1 extends CameraBarcodeScanViewBase<byte[]> implemen
     @Override
     public void surfaceDestroyed(SurfaceHolder holder) {
         Log.i(TAG, "surface destroyed");
+        isSurfaceCreated = false;
         cleanUp();
     }
+
+    @Override
+    public void resetSurface() {
+        if (isSurfaceCreated) {
+            // Camera is already initialized, just reset the preview
+            // When locking the screen on old Android device, the surface is not destroyed by
+            // the Android lifecycle. We have to reset the camera preview after the cleanup.
+            surfaceCreated(cameraSurfaceHolder);
+        }
+    }
+
     //
     ////////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/enioka_scan_camera/src/main/java/com/enioka/scanner/sdk/camera/CameraBarcodeScanViewV2.java
+++ b/enioka_scan_camera/src/main/java/com/enioka/scanner/sdk/camera/CameraBarcodeScanViewV2.java
@@ -593,6 +593,11 @@ class CameraBarcodeScanViewV2 extends CameraBarcodeScanViewBase<Image> {
         closeCamera();
     }
 
+    @Override
+    public void resetSurface() {
+        // Do nothing
+    }
+
 
     ///////////////////////////////////////////////////////////////////////////
     // CameraDevice.StateCallback


### PR DESCRIPTION
https://github.com/enioka-Haute-Couture/enioka_scan/issues/204

- When initializing the camera, check whether the camera preview surface has not been destroyed. In this case, reset it to display the camera preview correctly.